### PR TITLE
we don't render no-devices-message if devices are still loading; stoc…

### DIFF
--- a/client/src/components/DeviceSection.jsx
+++ b/client/src/components/DeviceSection.jsx
@@ -42,7 +42,7 @@ const DeviceSection = observer(({ isLoading, retryDevicesFetch, error }) => {
             saleTypeNames={deviceStore.saleTypeNames}
           />
         )
-        : (!error && !!Object.keys(deviceStore.usedFilters).length) && (
+        : (!error && !!Object.keys(deviceStore.usedFilters).length && !isLoading) && (
           <p className="no-devices-message">
             We haven't found devices with such filters {":("}
           </p>

--- a/client/src/hooks/useDeviceSectionFetching.js
+++ b/client/src/hooks/useDeviceSectionFetching.js
@@ -102,7 +102,9 @@ function useDeviceSectionFetching(deviceStore, app, originalType, setIsFoundDevi
       // TODO: add there other "special" filters (that requires separate implementation) later on
       const isSpecialFilters = toFilterByPrice || toFilterByStock || toFilterBySeller || toFilterByBrand;
   
-      let filteredDevices = [...devices];
+      // we clone devices array deeply to prevent changing of a device combos
+      // (it's important for stock filter because it doesn't change on using it)
+      let filteredDevices = _.cloneDeep(devices);
       let pageFilteredDevices = [];
   
       if (toFilterByStock) {

--- a/client/src/pages/MainPage.jsx
+++ b/client/src/pages/MainPage.jsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useRef } from "react";
 import { Context } from "../Context";
 import UserLocationBtnNotification from "../components/UserLocationBtnNotification";
-import setSelfDeliveryModalVisibility from "../utils/setSelfDeliveryModalVisibility";
 
 const MainPage = () => {
   const { app } = useContext(Context);
@@ -15,9 +14,6 @@ const MainPage = () => {
     <div>
       MainPage
       <UserLocationBtnNotification />
-      <button onClick={() => setSelfDeliveryModalVisibility(true, app)}>
-        Open self delivery modal
-      </button>
     </div>
   );
 };


### PR DESCRIPTION
…k filter doesn't affected by devices' combinations filtering, so it doesn't change at all rn; deleted self delivery modal button on the main page